### PR TITLE
Building out serialize and digest functionality

### DIFF
--- a/src/vrs/spec.clj
+++ b/src/vrs/spec.clj
@@ -145,7 +145,11 @@
        (catch Throwable _)))
 
 (defn curie?
-  "Nil or [TYPE DIGEST] from OBJECT when it is a VRS CURIE string."
+  "Nil or [TYPE DIGEST] from OBJECT when it is a VRS CURIE string.
+
+   (spec/curie? \"ga4gh:VT.01234567890123456789012345678901\")
+
+   [\"VT\" \"01234567890123456789012345678901\"]"
   [object]
   (try (let [[curie? _ga4gh type digest] (re-matches curie-regex object)]
          (when curie? [type digest]))


### PR DESCRIPTION
The test cases in [`vrs/validation/functions.yaml`](https://github.com/ga4gh/vrs/blob/c4595ae173e10195e6a7157364a6edb5a7276283/validation/functions.yaml) are limited and do not cover enough use cases to validate real variant structures with nested vrs-identifiable objects. This PR will expand functionality to handle additional structures.

* Resolves #4. Recursively order map keys in digest/canonicalize.